### PR TITLE
Reduce omnibox keyword, rename omnibox display name and update description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Short",
-  "short_name": "Short Ext",
-  "version": "0.0.3",
-  "description": "Short allows you to visit short links using prefix s/ instead of https://s.time4hacks.com/r/",
+  "short_name": "Short",
+  "version": "0.0.4",
+  "description": "Visit short links with less typing",
   "manifest_version": 2,
   "background": {
     "scripts": [
@@ -16,7 +16,7 @@
     "webRequestBlocking"
   ],
   "omnibox": {
-    "keyword" : "short"
+    "keyword" : "s"
   },
   "icons": {
     "16": "icons/logo-16.png",


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Omnibox with name `Short Ext` shows up when user types `short` and press `tab`.
### Screenshots
<img width="549" alt="Screen Shot 2019-08-25 at 9 15 25 AM" src="https://user-images.githubusercontent.com/3537801/63652761-e795af80-c718-11e9-97eb-16af42bf1a61.png">


## New Behavior
### Description
Omnibox with name `Short` shows up when user types `s` and press `tab`.
### Screenshots
<img width="818" alt="Screen Shot 2019-08-25 at 8 46 16 AM" src="https://user-images.githubusercontent.com/3537801/63652724-6f2eee80-c718-11e9-90ac-9e9d18ff4840.png">
