### PR TITLE
Fix build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Replace `APP_BASE_URL` with the URL of the web frontend.
 ### Build
 ```
 yarn
-yarn run build
+./scripts/build
 ```
 
 ### Install

--- a/scripts/build
+++ b/scripts/build
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
+yarn prep
 yarn build
 
 mkdir -p build/short-ext
 
 mv build/background.js build/short-ext/
-cp manifest.json build/short-ext/
+cp build/manifest.json build/short-ext/
 cp -r icons build/short-ext/
 
 zip -r build/short-ext.zip build/short-ext/* -x "*.DS_Store"


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The build script copies `manifest.json` file outside `build` directory.

## New Behavior
### Description
The build script copies incorrect `manifest.json` in side `build` directory with correct `APP_BASE_URL` configured.
