### PR TITLE
Fix build script

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,4 +9,5 @@ mv build/background.js build/short-ext/
 cp build/manifest.json build/short-ext/
 cp -r icons build/short-ext/
 
-zip -r build/short-ext.zip build/short-ext/* -x "*.DS_Store"
+cd build || exit
+zip -r short-ext.zip short-ext/* -x "*.DS_Store"


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
`short-ext.zip` contains extra `build` directory outside extension root. This prevents the unzipped directory from being loaded by Chrome extension manager directly.

## New Behavior
### Description
Removed the outer `build` directory.
