### PR TITLE
Get version number of extension based on git tag dynamically

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,14 +4,18 @@ name: default
 
 steps:
   - name: build
-    image: node:12.7.0-alpine
+    image: docker
     commands:
-      - apk add --no-cache zip curl
-      - yarn
-      - GIT_TAG=$DRONE_TAG yarn build:production
-      - zip -r build/short-ext.zip build/* -x "*.DS_Store"
-      - curl google.com # replace it with the updating and publishing api
+      - docker build -t short-ext:latest --build-arg GIT_TAG=$DRONE_TAG .
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
 
 trigger:
   event:
     - tag
+
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,17 @@
+kind: pipeline
+type: docker
+name: default
+
+steps:
+  - name: build
+    image: node:12.7.0-alpine
+    commands:
+      - apk add --no-cache zip curl
+      - yarn
+      - GIT_TAG=$DRONE_TAG yarn build:production
+      - zip -r build/short-ext.zip build/* -x "*.DS_Store"
+      - curl google.com # replace it with the updating and publishing api
+
+trigger:
+  event:
+    - tag

--- a/.env.dist
+++ b/.env.dist
@@ -1,1 +1,2 @@
 APP_BASE_URL=http://localhost:3000
+GIT_TAG=0.0.1

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+APP_BASE_URL=http://*.short-d.com

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ node_modules
 /build
 
 # Environmental variables
-.env
+.env.development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12.7.0-alpine
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+ARG GIT_TAG
+
+RUN apk add --no-cache zip
+RUN yarn
+RUN yarn build:production

--- a/README.md
+++ b/README.md
@@ -18,9 +18,16 @@ cp .env.dist .env.development
 Replace `APP_BASE_URL` with the URL of the web frontend.
 
 ### Build
+#### Development mode:
 ```
 yarn
-./scripts/build
+yarn:development
+```
+
+#### Production mode:
+```
+yarn
+GIT_TAG=0.0.1 yarn build:production
 ```
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ cp .env.dist .env.development
 Replace `APP_BASE_URL` with the URL of the web frontend.
 
 ### Build
-#### Development mode:
+#### For Local Development
 ```
 yarn
 yarn:development
 ```
 
-#### Production mode:
+#### For Production Release
 ```
 yarn
 GIT_TAG=0.0.1 yarn build:production

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn
 ![](doc/screenshot/developer-mode.png)
 3. Click on `Load unpacked`.
 ![](doc/screenshot/load-unpacked.png)
-4. Select `build` directory.
+4. Select `build/short-ext` directory.
 5. **Short** should now up in extension list.
 ![](doc/screenshot/extension.png)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install from [Chrome Web Store](https://short-d.com/r/ext)
 ## Getting Started
 ### Setup
 ```bash
-cp .env.dist .env
+cp .env.dist .env.development
 ```
 Replace `APP_BASE_URL` with the URL of the web frontend.
 
@@ -29,7 +29,7 @@ yarn
 ![](doc/screenshot/developer-mode.png)
 3. Click on `Load unpacked`.
 ![](doc/screenshot/load-unpacked.png)
-4. Select `build/short-ext` directory.
+4. Select `build` directory.
 5. **Short** should now up in extension list.
 ![](doc/screenshot/extension.png)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Short",
   "short_name": "Short",
-  "version": "${CUR_GIT_TAG}",
+  "version": "${GIT_TAG}",
   "description": "Visit short links with less typing",
   "manifest_version": 2,
   "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Short",
   "short_name": "Short",
-  "version": "0.0.6",
+  "version": "${CUR_GIT_TAG}",
   "description": "Visit short links with less typing",
   "manifest_version": 2,
   "background": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://short-d.com/r/extcode"
   },
   "scripts": {
-    "build": "yarn cp:assets && envsub --env CUR_GIT_TAG=`git describe --tags --abbrev=0` --env-file .env build/manifest.json && tsc",
+    "build": "yarn cp:assets && envsub --env-file .env build/manifest.json && tsc",
     "prep": "rm -rf build && mkdir build",
     "dev": "yarn build --watch",
     "cp:assets": "cp -r icons manifest.json build/",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "url": "https://short-d.com/r/extcode"
   },
   "scripts": {
-    "build": "yarn cp:assets && envsub --env-file .env build/manifest.json && tsc",
+    "build": "yarn prep && yarn cp:assets && envsub --env-file .env.${APP_ENV} --all build/manifest.json && tsc",
+    "build:development": "APP_ENV=development yarn build",
+    "build:production": "APP_ENV=production yarn build",
     "prep": "rm -rf build && mkdir build",
     "dev": "yarn build --watch",
     "cp:assets": "cp -r icons manifest.json build/",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "url": "https://short-d.com/r/extcode"
   },
   "scripts": {
-    "build": "yarn prep && yarn cp:assets && envsub --env-file .env.${APP_ENV} --all build/manifest.json && tsc",
+    "build": "yarn prep && yarn cp:assets && yarn compile",
+    "compile": "envsub --env-file .env.${APP_ENV} --all build/manifest.json && tsc",
     "build:development": "APP_ENV=development yarn build",
-    "build:production": "APP_ENV=production yarn build",
+    "build:production": "APP_ENV=production yarn build && yarn zip:build",
+    "zip:build": "sh -ac 'zip -r build/short-ext.zip build/* -x \"*.DS_Store\"'",
     "prep": "rm -rf build && mkdir build",
-    "dev": "yarn build --watch",
+    "dev": "yarn build:development --watch",
     "cp:assets": "cp -r icons manifest.json build/",
     "prettier:base": "prettier --parser typescript --single-quote --tab-width 4",
     "prettier:check": "yarn prettier:base --list-different \"src/**/*.{ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://short-d.com/r/extcode"
   },
   "scripts": {
-    "build": "yarn prep && yarn cp:assets && envsub --env-file .env build/manifest.json && tsc",
+    "build": "yarn cp:assets && envsub --env CUR_GIT_TAG=`git describe --tags --abbrev=0` --env-file .env build/manifest.json && tsc",
     "prep": "rm -rf build && mkdir build",
     "dev": "yarn build --watch",
     "cp:assets": "cp -r icons manifest.json build/",

--- a/scripts/build
+++ b/scripts/build
@@ -6,8 +6,8 @@ yarn build
 mkdir -p build/short-ext
 
 mv build/background.js build/short-ext/
-cp build/manifest.json build/short-ext/
-cp -r icons build/short-ext/
+mv build/manifest.json build/short-ext/
+mv build/icons build/short-ext/
 
 cd build || exit
 zip -r short-ext.zip short-ext/* -x "*.DS_Store"

--- a/scripts/build
+++ b/scripts/build
@@ -1,13 +1,4 @@
 #!/usr/bin/env bash
 
-yarn prep
-yarn build
-
-mkdir -p build/short-ext
-
-mv build/background.js build/short-ext/
-mv build/manifest.json build/short-ext/
-mv build/icons build/short-ext/
-
-cd build || exit
-zip -r short-ext.zip short-ext/* -x "*.DS_Store"
+yarn
+yarn build:development

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-yarn
-yarn build:development


### PR DESCRIPTION
Fixes #29 
### Description
- [x] Replace version in manifest.json with an environmental variable.
- [x] Update the build script to pass TAG env as VERSION env.
- [x] Create Drone CI configuration (https://github.com/short-d/short/blob/master/.drone.yml) to listen to tag event and pass DRONE_TAG to the build script.