### PR TITLE
Add publishing the extension step to drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,6 +11,28 @@ steps:
       - name: docker
         path: /var/run/docker.sock
 
+  - name: upload and publish extension
+    image: docker
+    environment:
+      EXTENSION_ID:
+        from_secret: EXTENSION_ID
+      CLIENT_ID:
+        from_secret: CLIENT_ID
+      CLIENT_SECRET:
+        from_secret: CLIENT_SECRET
+      REFRESH_TOKEN:
+        from_secret: REFRESH_TOKEN
+    commands:
+      - docker run
+        --env EXTENSION_ID=$EXTENSION_ID
+        --env CLIENT_ID=$CLIENT_ID
+        --env CLIENT_SECRET=$CLIENT_SECRET
+        --env REFRESH_TOKEN=$REFRESH_TOKEN
+        short-ext
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+
 trigger:
   event:
     - tag

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 
 # Environmental variables
 .env.development
+
+# macOS metadata
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,9 @@ RUN yarn
 RUN yarn build:production
 RUN yarn global add chrome-webstore-upload-cli@1.2.0
 
-CMD webstore upload --auto-publish --source build/short-ext.zip --extension-id $EXTENSION_ID --client-id $CLIENT_ID --client-secret $CLIENT_SECRET --refresh-token $REFRESH_TOKEN
+CMD webstore upload --auto-publish \
+    --source build/short-ext.zip \
+    --extension-id $EXTENSION_ID \
+    --client-id $CLIENT_ID \
+    --client-secret $CLIENT_SECRET \
+    --refresh-token $REFRESH_TOKEN

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,6 @@ ARG GIT_TAG
 RUN apk add --no-cache zip
 RUN yarn
 RUN yarn build:production
+RUN yarn global add chrome-webstore-upload-cli@1.2.0
+
+CMD webstore upload --auto-publish --source build/short-ext.zip --extension-id $EXTENSION_ID --client-id $CLIENT_ID --client-secret $CLIENT_SECRET --refresh-token $REFRESH_TOKEN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "Short",
-  "version": "0.0.6",
   "description": "Visit short links with less typing",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR along with #30 fixes #28 completely.
### Description
Uploads and publishes the extension application to chrome web store

#### Side note:
The chrome webstore upload we use has quite a lot of dependencies and would increase dev build time unnecessarily for a dependency which is used only while publishing. So, I am not adding it to our project. Instead I am installing it inside the docker container which publishes the extension.