### PR TITLE
Fix APP_BASE_URL for production extension

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-APP_BASE_URL=http://*.short-d.com
+APP_BASE_URL=*://*.short-d.com


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The extension is only connectable when the user visits `short-d.com` with `HTTP` protocol. However, the production site automatically redirect all traffic to `HTTPS`.

### Screenshots
<img width="847" alt="Screen Shot 2020-03-18 at 6 01 40 PM" src="https://user-images.githubusercontent.com/3537801/77020933-8b0f1180-6942-11ea-9e1a-8f646db481b5.png">

## New Behavior
### Description
The extension is connectable by either HTTP or HTTPS.
