### PR TITLE
Fix dev build instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Replace `APP_BASE_URL` with the URL of the web frontend.
 #### For Local Development
 ```
 yarn
-yarn:development
+yarn build:development
 ```
 
 #### For Production Release


### PR DESCRIPTION
Fixes #40 
### Description
Modify `yarn:development` to `yarn build:development` in README.